### PR TITLE
added this index file back, this is what @cashew/common compiles

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,0 +1,5 @@
+// this is the source file while compiles @cashew/common, imported into web/
+
+import { actions, appState, INITIAL_STATE, store } from "./redux/index"
+
+export { actions, appState, store, INITIAL_STATE }

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,9 +1,11 @@
-import { actions, AppState, store } from "@cashew/common"
 import {
+    actions,
+    AppState,
     DecrementAction,
     IncrementAction,
     ResetAction,
-} from "@cashew/common/src/redux/modules/counter"
+    store,
+} from "@cashew/common"
 
 import * as React from "react"
 import { connect } from "react-redux"
@@ -19,6 +21,7 @@ interface AppProps {
         reset: () => ResetAction
     }
 }
+
 class App extends React.Component<AppProps> {
     constructor(props: AppProps) {
         super(props)


### PR DESCRIPTION
### FIX

I initially had this working but then I had an issue where the build watcher seemed to not be working. But it was because I had moved the logic into `redux` and deleted this index file. BUT this is where @cashew/common compiles from so it needs to be here.